### PR TITLE
fix: Fix event cron job in 60 seconds

### DIFF
--- a/source/lib/aws-instance-scheduler-stack.ts
+++ b/source/lib/aws-instance-scheduler-stack.ts
@@ -612,7 +612,7 @@ export class AwsInstanceSchedulerStack extends cdk.Stack {
     mappings.setValue("Timeouts", "10", "cron(0/10 * * * ? *)")
     mappings.setValue("Timeouts", "15", "cron(0/15 * * * ? *)")
     mappings.setValue("Timeouts", "30", "cron(0/30 * * * ? *)")
-    mappings.setValue("Timeouts", "60", "cron(0/1 * * ? *)")
+    mappings.setValue("Timeouts", "60", "cron(0 */1 * * ? *)")
     mappings.setValue("Settings", "MetricsUrl", "https://metrics.awssolutionsbuilder.com/generic")
     mappings.setValue("Settings", "MetricsSolutionId", "S00030")
 


### PR DESCRIPTION
1. It should be 60 seconds not 1 second.
2. Add back one field to Cron expression.